### PR TITLE
Resize menu cards globally

### DIFF
--- a/frontend/src/components/MenuPage/Dishecard.tsx
+++ b/frontend/src/components/MenuPage/Dishecard.tsx
@@ -6,7 +6,7 @@ interface DishecardProps extends MenuItem {
 
 const Dishecard = ({ image, title, description, price, tag, showTag }: DishecardProps) => {
   return (
-    <div className="flex flex-col items-center justify-center max-w-xs overflow-hidden transition-all duration-100 bg-white rounded shadow-lg cursor-pointer hover:ease-in-out hover:shadow-2xl">
+    <div className="h-full flex flex-col items-center justify-center max-w-xs overflow-hidden transition-all duration-100 bg-white rounded shadow-lg cursor-pointer hover:ease-in-out hover:shadow-2xl">
       <div className="flex items-center justify-center w-full h-40">
         <img className="object-contain max-h-full rounded-lg" src={image} alt={title + ' image'} />
       </div>


### PR DESCRIPTION
### What does this PR do?

Added the menu card compoment hight to 100% which will cover the parent flexbox area.

Fixed #4 

### Type of changes

- Add the new class on `Menucard` component.

### Screenshots
![Screenshot 2024-10-08 215522](https://github.com/user-attachments/assets/3ce53bb6-594c-4b8f-ac73-c9e1b5e63286)
